### PR TITLE
Fault injector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable( Harris
 	./src/util.cpp
 	./src/harris.cpp
 	./src/main.cpp
+	./src/injector.cpp
 )
 
 target_include_directories( Harris

--- a/README.md
+++ b/README.md
@@ -25,3 +25,28 @@ cmake -D arm=true ..
 make
 ```
 The executable won't run on your machine, you will need to scp it to the arm platform and run it there. 
+
+
+## Fault Injector
+
+A simple fault injector is included with the project. The fault injector is designed to be embedded into the code to inject data bit flips into the code based on a predefined operating strategy or "mode". There are three primary modes:
+
+- **SINGLE_DATA:** Injects a single bit flip into whatever data object is passed into the `inject()` function.
+
+- **DOUBLE_DATA:** Injects two unique bit flips into whatever data object is passed into the `inject()` function.
+
+- **PROB_DATA:** Injects errors into each bit in the data object based on the `bit_hit_prob` passed into the injector constructor or set using the `setBHP()` function. For example if `bit_hit_prob = .1` there is a 10% chance that a given bit will be flipped. this corresponds to a 56.9% chance of at least one fault in a given byte. 
+
+### Example usage
+Specific usage will vary but may look like this:
+```
+injector fi(PROB_DATA, 1e-3);
+fi.enable();
+...
+fi.inject(aMatVar);
+...
+fi.inject(aDoubleVar, SINGLE_DATA); // uses SINGLE_DATA mode for this injection only
+...
+fi.disable()
+cout<<fi.stats()<<endl;
+```

--- a/include/injector.h
+++ b/include/injector.h
@@ -13,6 +13,9 @@
 #define INJECTOR_H
 
 #include <opencv2/opencv.hpp>
+#include <chrono>
+
+typedef std::chrono::_V2::system_clock::time_point injector_time_t;
 
 typedef enum{
     SINGLE_DATA, // single bit error injected for each inject call
@@ -25,9 +28,11 @@ class injector
 {
 private:
     INJECTOR_MODE_TYPE default_mode; // default mode for injections
-    double bit_hit_prob; // probability of a single memory bit being hit
-    bool enabled; // true when fault injection is enabled
-    unsigned int injections; // total number of injections performed
+    double bit_hit_prob;             // probability of a single memory bit being hit
+    bool enabled;                    // true when fault injection is enabled
+    unsigned long int injections;    // total number of injections performed
+    unsigned long int total_time;    // total time (us) used by injector
+    injector_time_t last_start;      // last system start time
 
 public:
     // create an injector initialized with the specific default mode
@@ -57,7 +62,11 @@ public:
     // returns injection statistics as a string
     std::string stats(void);
 
-    
+    // starts timing injector function
+    void tic(void);
+
+    // finish timing injector and add count to total_time
+    void toc(void);
 
 };
 

--- a/include/injector.h
+++ b/include/injector.h
@@ -33,10 +33,10 @@ public:
     void disable(void);
 
     // injects faults into arbitrary c++ data type with mode specified
-    template <class T> void inject(T &data, INJECTOR_MODE_TYPE mode);
+    template <typename T> void inject(T &data, INJECTOR_MODE_TYPE mode);
 
     // injects faults into arbitrary c++ data type with default mode
-    template <class T> void inject(T &data);
+    template <typename T> void inject(T &data);
 
     // injects faults into openCV Mat
     void inject(cv::Mat &data, INJECTOR_MODE_TYPE mode);

--- a/include/injector.h
+++ b/include/injector.h
@@ -1,0 +1,54 @@
+#ifndef INJECTOR_H
+#define INJECTOR_H
+
+#include <opencv2/opencv.hpp>
+
+typedef enum{
+    SINGLE_DATA, // single bit error injected for each inject call
+    DOUBLE_DATA, // double bit error injected for each inject call
+    MIXED_DATA,  // random mix of single and double bit errors
+    PROB_DATA,   // injections made based on probability model
+    NONE         // injections not performed
+} INJECTOR_MODE_TYPE;
+
+class injector
+{
+private:
+    INJECTOR_MODE_TYPE default_mode; // default mode for injections
+    double mem_bit_hit_prob; // probability of a single memory bit being hit
+    double reg_bit_hit_prob; // probability of a single register bit being hit
+    bool enabled; // true when fault injection is enabled
+    unsigned int injections;
+    unsigned int mem_injections;
+    unsigned int reg_injections;
+
+public:
+    // create an injector initialized with the specific default mode
+    injector(INJECTOR_MODE_TYPE mode, double mhp, double rhp);
+
+    // enable fault injection
+    void enable(void);
+
+    // disable fault injection
+    void disable(void);
+
+    // injects faults into arbitrary c++ data type with mode specified
+    template <class T> void inject(T &data, INJECTOR_MODE_TYPE mode);
+
+    // injects faults into arbitrary c++ data type with default mode
+    template <class T> void inject(T &data);
+
+    // injects faults into openCV Mat
+    void inject(cv::Mat &data, INJECTOR_MODE_TYPE mode);
+
+    // injects faults into openCV Mat with default mode
+    void inject(cv::Mat &data);
+
+    // returns injection statistics as a string
+    std::string stats(void);
+
+};
+
+//#include "../src/injector.cpp"
+
+#endif

--- a/include/injector.h
+++ b/include/injector.h
@@ -17,7 +17,6 @@
 typedef enum{
     SINGLE_DATA, // single bit error injected for each inject call
     DOUBLE_DATA, // double bit error injected for each inject call
-    MIXED_DATA,  // random mix of single and double bit errors
     PROB_DATA,   // injections made based on probability model
     NONE         // injections not performed
 } INJECTOR_MODE_TYPE;
@@ -32,13 +31,16 @@ private:
 
 public:
     // create an injector initialized with the specific default mode
-    injector(INJECTOR_MODE_TYPE mode, double mhp, double rhp);
+    injector(INJECTOR_MODE_TYPE mode, double bhp);
 
     // enable fault injection
     void enable(void);
 
     // disable fault injection
     void disable(void);
+
+    // change bit hit probability
+    void setBHP(double bhp);
 
     // injects faults into arbitrary c++ data type with mode specified
     template <typename T> void inject(T &data, INJECTOR_MODE_TYPE mode);
@@ -54,6 +56,8 @@ public:
 
     // returns injection statistics as a string
     std::string stats(void);
+
+    
 
 };
 

--- a/include/injector.h
+++ b/include/injector.h
@@ -68,6 +68,9 @@ public:
     // finish timing injector and add count to total_time
     void toc(void);
 
+    // returns the current time expended by injector in us
+    unsigned long int getTime(void);
+
 };
 
 #endif

--- a/include/injector.h
+++ b/include/injector.h
@@ -1,3 +1,14 @@
+/**
+ * @file injector.h
+ * @author Daniel Stumpp
+ * @brief fault injector for arbitary c++ types and openCV Mat types
+ * @version 0.1
+ * @date 2020-11-16
+ * 
+ * @copyright Copyright (c) 2020
+ * 
+ */
+
 #ifndef INJECTOR_H
 #define INJECTOR_H
 
@@ -15,12 +26,9 @@ class injector
 {
 private:
     INJECTOR_MODE_TYPE default_mode; // default mode for injections
-    double mem_bit_hit_prob; // probability of a single memory bit being hit
-    double reg_bit_hit_prob; // probability of a single register bit being hit
+    double bit_hit_prob; // probability of a single memory bit being hit
     bool enabled; // true when fault injection is enabled
-    unsigned int injections;
-    unsigned int mem_injections;
-    unsigned int reg_injections;
+    unsigned int injections; // total number of injections performed
 
 public:
     // create an injector initialized with the specific default mode
@@ -48,7 +56,5 @@ public:
     std::string stats(void);
 
 };
-
-//#include "../src/injector.cpp"
 
 #endif

--- a/src/harris.cpp
+++ b/src/harris.cpp
@@ -9,6 +9,8 @@ using namespace std::chrono;
 
 Harris::Harris(Mat img, float k, int filterRange, bool gauss) {
 
+    injector fi(NONE, .4);
+
     // (1) Convert to greyscale image
     auto t_start = high_resolution_clock::now();
     Mat greyscaleImg = convertRgbToGrayscale(img);

--- a/src/harris.cpp
+++ b/src/harris.cpp
@@ -10,10 +10,10 @@ using namespace std::chrono;
 Harris::Harris(Mat img, float k, int filterRange, bool gauss) {
 
     //test injector init
-    injector fi(NONE, .5, .5);
+    injector fi(NONE, .01, .01);
     Mat m1 = Mat(3,3, CV_32F, float(400));
     cout<<m1<<endl;
-    fi.inject(m1,SINGLE_DATA);
+    fi.inject(m1,PROB_DATA);
     cout<<m1<<endl;
 
     std::cout<<fi.stats();

--- a/src/harris.cpp
+++ b/src/harris.cpp
@@ -9,8 +9,6 @@ using namespace std::chrono;
 
 Harris::Harris(Mat img, float k, int filterRange, bool gauss) {
 
-    injector fi(NONE, .4);
-
     // (1) Convert to greyscale image
     auto t_start = high_resolution_clock::now();
     Mat greyscaleImg = convertRgbToGrayscale(img);

--- a/src/harris.cpp
+++ b/src/harris.cpp
@@ -11,10 +11,10 @@ Harris::Harris(Mat img, float k, int filterRange, bool gauss) {
 
     //test injector init
     injector fi(NONE, 1e-6, 1e-6);
-    int test = 255;
-    cout<<test<<endl;
-    fi.inject(test,SINGLE_DATA);
-    cout<<test<<endl;
+    int8_t test = 0;
+    cout<<(int)test<<endl;
+    fi.inject(test,DOUBLE_DATA);
+    cout<<(int)test<<endl;
 
     std::cout<<fi.stats();
 

--- a/src/harris.cpp
+++ b/src/harris.cpp
@@ -242,7 +242,6 @@ Mat Harris::computeHarrisResponses(float k, Derivatives& d) {
 
             float det = a11*a22 - a12*a21;
             float trace = a11 + a22;
-
             M.at<float>(r,c) = abs(det - k * trace*trace);
         }
     }

--- a/src/harris.cpp
+++ b/src/harris.cpp
@@ -9,15 +9,6 @@ using namespace std::chrono;
 
 Harris::Harris(Mat img, float k, int filterRange, bool gauss) {
 
-    //test injector init
-    injector fi(NONE, .01, .01);
-    Mat m1 = Mat(3,3, CV_32F, float(400));
-    cout<<m1<<endl;
-    fi.inject(m1,PROB_DATA);
-    cout<<m1<<endl;
-
-    std::cout<<fi.stats();
-
     // (1) Convert to greyscale image
     auto t_start = high_resolution_clock::now();
     Mat greyscaleImg = convertRgbToGrayscale(img);

--- a/src/harris.cpp
+++ b/src/harris.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "../include/harris.h"
+#include "../include/injector.h"
 #include <chrono>
 using namespace std::chrono;
 

--- a/src/harris.cpp
+++ b/src/harris.cpp
@@ -11,10 +11,10 @@ Harris::Harris(Mat img, float k, int filterRange, bool gauss) {
 
     //test injector init
     injector fi(NONE, .5, .5);
-    int8_t test = 0;
-    cout<<(int)test<<endl;
-    fi.inject(test,PROB_DATA);
-    cout<<(int)test<<endl;
+    Mat m1 = Mat(3,3, CV_32F, float(400));
+    cout<<m1<<endl;
+    fi.inject(m1,SINGLE_DATA);
+    cout<<m1<<endl;
 
     std::cout<<fi.stats();
 

--- a/src/harris.cpp
+++ b/src/harris.cpp
@@ -9,6 +9,15 @@ using namespace std::chrono;
 
 Harris::Harris(Mat img, float k, int filterRange, bool gauss) {
 
+    //test injector init
+    injector fi(NONE, 1e-6, 1e-6);
+    int test = 255;
+    cout<<test<<endl;
+    fi.inject(test,SINGLE_DATA);
+    cout<<test<<endl;
+
+    std::cout<<fi.stats();
+
     // (1) Convert to greyscale image
     auto t_start = high_resolution_clock::now();
     Mat greyscaleImg = convertRgbToGrayscale(img);

--- a/src/harris.cpp
+++ b/src/harris.cpp
@@ -10,10 +10,10 @@ using namespace std::chrono;
 Harris::Harris(Mat img, float k, int filterRange, bool gauss) {
 
     //test injector init
-    injector fi(NONE, 1e-6, 1e-6);
+    injector fi(NONE, .5, .5);
     int8_t test = 0;
     cout<<(int)test<<endl;
-    fi.inject(test,DOUBLE_DATA);
+    fi.inject(test,PROB_DATA);
     cout<<(int)test<<endl;
 
     std::cout<<fi.stats();

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -57,7 +57,7 @@ template <typename T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
         int bytePos = std::rand() % size; // randomly generate byte pos
         int bitPos = std::rand() % 8;     // randomly generate bit pos
 
-        uint8_t mask = std::pow(2,bitPos); // generate bit mask
+        uint8_t mask = 1 << bitPos; // generate bit mask
 
         bytes[bytePos] ^= mask; // flip bit in vale
         injections++;
@@ -73,8 +73,8 @@ template <typename T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
             bitPos2 = std::rand() % 8;
         } while (bitPos1 == bitPos2 && bytePos1 == bytePos2);
 
-        uint8_t mask1 = std::pow(2,bitPos1); // generate bit mask
-        uint8_t mask2 = std::pow(2,bitPos2);
+        uint8_t mask1 = static_cast<uint8_t>(1 << bitPos1); // generate bit mask
+        uint8_t mask2 = static_cast<uint8_t>(1 << bitPos2);
 
         bytes[bytePos1] ^= mask1;
         bytes[bytePos2] ^= mask2;
@@ -92,7 +92,7 @@ template <typename T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
                 unsigned long int safe = std::rand() % oneOutOf;
                 if (!safe)
                 {
-                    bytes[by] ^= static_cast<uint8_t>(std::pow(2,bi));
+                    bytes[by] ^= static_cast<uint8_t>(1 << bi);
                     injections++;
                 }
             }

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -18,6 +18,7 @@ injector::injector(INJECTOR_MODE_TYPE mode = NONE, double bhp = 0)
     bit_hit_prob = bhp;
     default_mode = mode;
     injections = 0;
+    total_time = 0;
 
     std::srand(time(NULL)); // seed rng
 }
@@ -171,6 +172,18 @@ std::string injector::stats(void)
     
     return ("Default Mode: " + mode_str + "\nTotal Injections: " + \
              std::to_string(injections) + "\n");
+}
+
+void injector::tic(void)
+{
+    last_time = std::chrono::high_resolution_clock::now();
+}
+
+void injector::toc(void)
+{
+    injector_time_t stop = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - last_time);
+    total_time += duration;
 }
 
 // explicitly defines valid template types

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -100,20 +100,35 @@ void injector::inject(cv::Mat &data, INJECTOR_MODE_TYPE mode)
         {
             int rowPos = std::rand() % rows;
             int colPos = std::rand() % cols;
-            int bytePos = std::rand() % sizeof(float);
-            int bitPos = std::rand() % 8;
 
-            float val = data.at<float>(rowPos, colPos);
-            uint8_t *bytes = reinterpret_cast<uint8_t*>(&val);
-            bytes[bytePos] ^= static_cast<uint8_t>(std::pow(2,bitPos));
-            data.at<float>(rowPos, colPos) = val;
+            inject(data.at<float>(rowPos, colPos), SINGLE_DATA);
+        }
+        else if (mode == DOUBLE_DATA)
+        {
+            int rowPos1 = std::rand() % rows;
+            int colPos1 = std::rand() % cols;
+            int rowPos2, colPos2;
+            do
+            {
+                rowPos2 = std::rand() % rows;
+                colPos2 = std::rand() % cols;
+            } while (colPos1 == colPos2 && rowPos1 == rowPos2);
+
+            inject(data.at<float>(rowPos1, colPos1), SINGLE_DATA);
+            inject(data.at<float>(rowPos2, colPos2), SINGLE_DATA);
+        }
+        else if (mode == PROB_DATA)
+        {
+            for (int r = 0; r < rows; ++r)
+            {
+                for (int c = 0; c < cols; ++c)
+                {
+                    inject(data.at<float>(r,c), PROB_DATA);
+                }
+            }
         }
     }
     
-    
-    
-    injections++;
-    return;
 }
 
 void injector::inject(cv::Mat &data)

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -2,6 +2,7 @@
 #include "../include/injector.h"
 #include <inttypes.h>
 #include <time.h>
+#include <opencv2/opencv.hpp>
 
 injector::injector(INJECTOR_MODE_TYPE mode = NONE, double mhp = 0, double rhp = 0)
 {
@@ -77,9 +78,6 @@ template <typename T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
         }
 
     }
-
-    
-    return;
 }
 
 template <typename T> void injector::inject(T &data)
@@ -90,6 +88,30 @@ template <typename T> void injector::inject(T &data)
 
 void injector::inject(cv::Mat &data, INJECTOR_MODE_TYPE mode)
 {
+    int rows = data.rows;
+    int cols = data.cols;
+    int type = data.type();
+
+    // injection strategy is different for different types
+    if (type == CV_32F)
+    {
+        // select injection type
+        if (mode == SINGLE_DATA)
+        {
+            int rowPos = std::rand() % rows;
+            int colPos = std::rand() % cols;
+            int bytePos = std::rand() % sizeof(float);
+            int bitPos = std::rand() % 8;
+
+            float val = data.at<float>(rowPos, colPos);
+            uint8_t *bytes = reinterpret_cast<uint8_t*>(&val);
+            bytes[bytePos] ^= static_cast<uint8_t>(std::pow(2,bitPos));
+            data.at<float>(rowPos, colPos) = val;
+        }
+    }
+    
+    
+    
     injections++;
     return;
 }

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -32,7 +32,7 @@ void injector::disable(void)
     enabled = false;
 }
 
-void injetor::setBHP(double bhp)
+void injector::setBHP(double bhp)
 {
     bit_hit_prob = bhp;
 }

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -1,0 +1,72 @@
+#include "../include/injector.h"
+
+injector::injector(INJECTOR_MODE_TYPE mode, double mhp = 0, double rhp = 0)
+{
+    mem_bit_hit_prob = mhp;
+    reg_bit_hit_prob = rhp;
+    default_mode = mode;
+}
+
+void injector::enable(void)
+{
+    enabled = true;
+}
+
+void injector::disable(void)
+{
+    enabled = false;
+}
+
+template <class T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
+{
+    injections++;
+    return;
+}
+
+template <class T> void injector::inject(T &data)
+{
+    // call injector with default mode
+    inject(data, default_mode);
+}
+
+void injector::inject(cv::Mat &data, INJECTOR_MODE_TYPE mode)
+{
+    injections++;
+    return;
+}
+
+void injector::inject(cv::Mat &data)
+{
+    // call Mat injector with default mode
+    inject(data, default_mode);
+}
+
+std::string injector::stats(void)
+{
+    std::string mode_str = "";
+    switch (default_mode)
+    {
+    case SINGLE_DATA:
+        mode_str = "SINGLE_DATA";
+        break;
+    case DOUBLE_DATA:
+        mode_str = "DOUBLE_DATA";
+        break;
+    case MIXED_DATA:
+        mode_str = "MIXED_DATA";
+        break;
+    case PROB_DATA:
+        mode_str = "PROB_DATA";
+        break;
+    case NONE:
+        mode_str = "NONE";
+        break;
+    default:
+        break;
+    }
+    
+    return ("Default Mode: " + mode_str + "\nTotal Injections: " + \
+             std::to_string(injections) + "\nTotal Injections: " + \
+             std::to_string(mem_injections) + "Reg Injections: " + \
+             std::to_string(reg_injections) + "\n");
+}

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -39,6 +39,24 @@ template <typename T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
 
         bytes[bytePos] ^= mask; // flip bit in vale
     }
+    else if (mode == DOUBLE_DATA)
+    {
+        int bytePos1 = std::rand() % size; // randomly generate byte pos
+        int bitPos1 = std::rand() % 8;     // randomly generate bit pos
+        int bytePos2, bitPos2;
+        do 
+        {
+            bytePos2 = std::rand() % size;
+            bitPos2 = std::rand() % 8;
+        } while (bitPos1 == bitPos2 && bytePos1 == bytePos2);
+
+        uint8_t mask1 = std::pow(2,bitPos1); // generate bit mask
+        uint8_t mask2 = std::pow(2,bitPos2);
+
+        bytes[bytePos1] ^= mask1;
+        bytes[bytePos2] ^= mask2;        
+    }
+
     injections++;
     return;
 }

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -13,14 +13,11 @@
 #include <inttypes.h>
 #include <time.h>
 
-injector::injector(INJECTOR_MODE_TYPE mode = NONE, double mhp = 0, double rhp = 0)
+injector::injector(INJECTOR_MODE_TYPE mode = NONE, double bhp = 0)
 {
-    mem_bit_hit_prob = mhp;
-    reg_bit_hit_prob = rhp;
+    bit_hit_prob = bhp;
     default_mode = mode;
     injections = 0;
-    mem_injections = 0;
-    reg_injections = 0;
 
     std::srand(time(NULL)); // seed rng
 }
@@ -33,6 +30,11 @@ void injector::enable(void)
 void injector::disable(void)
 {
     enabled = false;
+}
+
+void injetor::setBHP(double bhp)
+{
+    bit_hit_prob = bhp;
 }
 
 template <typename T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
@@ -156,9 +158,6 @@ std::string injector::stats(void)
         break;
     case DOUBLE_DATA:
         mode_str = "DOUBLE_DATA";
-        break;
-    case MIXED_DATA:
-        mode_str = "MIXED_DATA";
         break;
     case PROB_DATA:
         mode_str = "PROB_DATA";

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -1,8 +1,17 @@
+/**
+ * @file injector.cpp
+ * @author Daniel Stumpp
+ * @brief fault injector implementation
+ * @version 0.1
+ * @date 2020-11-16
+ * 
+ * @copyright Copyright (c) 2020
+ * 
+ */
 
 #include "../include/injector.h"
 #include <inttypes.h>
 #include <time.h>
-#include <opencv2/opencv.hpp>
 
 injector::injector(INJECTOR_MODE_TYPE mode = NONE, double mhp = 0, double rhp = 0)
 {
@@ -61,7 +70,7 @@ template <typename T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
     }
     else if (mode == PROB_DATA)
     {
-        unsigned long int oneOutOf = static_cast<unsigned long int>(1.0/reg_bit_hit_prob);
+        unsigned long int oneOutOf = static_cast<unsigned long int>(1.0/bit_hit_prob);
         
         // determine if each bit get's hit based on prob
         for (int by = 0; by < size; ++by)
@@ -162,9 +171,7 @@ std::string injector::stats(void)
     }
     
     return ("Default Mode: " + mode_str + "\nTotal Injections: " + \
-             std::to_string(injections) + "\nTotal Injections: "  + \
-             std::to_string(mem_injections) + "\nReg Injections: " + \
-             std::to_string(reg_injections) + "\n");
+             std::to_string(injections) + "\n");
 }
 
 // explicitly defines valid template types

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -1,10 +1,18 @@
-#include "../include/injector.h"
 
-injector::injector(INJECTOR_MODE_TYPE mode, double mhp = 0, double rhp = 0)
+#include "../include/injector.h"
+#include <inttypes.h>
+#include <time.h>
+
+injector::injector(INJECTOR_MODE_TYPE mode = NONE, double mhp = 0, double rhp = 0)
 {
     mem_bit_hit_prob = mhp;
     reg_bit_hit_prob = rhp;
     default_mode = mode;
+    injections = 0;
+    mem_injections = 0;
+    reg_injections = 0;
+
+    std::srand(time(NULL)); // seed rng
 }
 
 void injector::enable(void)
@@ -17,13 +25,25 @@ void injector::disable(void)
     enabled = false;
 }
 
-template <class T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
+template <typename T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
 {
+    int size = sizeof(T);
+    uint8_t *bytes = reinterpret_cast<uint8_t*>(&data);
+    
+    if (mode == SINGLE_DATA)
+    {      
+        int bytePos = std::rand() % size; // randomly generate byte pos
+        int bitPos = std::rand() % 8;     // randomly generate bit pos
+
+        uint8_t mask = std::pow(2,bitPos); // generate bit mask
+
+        bytes[bytePos] ^= mask; // flip bit in vale
+    }
     injections++;
     return;
 }
 
-template <class T> void injector::inject(T &data)
+template <typename T> void injector::inject(T &data)
 {
     // call injector with default mode
     inject(data, default_mode);
@@ -66,7 +86,34 @@ std::string injector::stats(void)
     }
     
     return ("Default Mode: " + mode_str + "\nTotal Injections: " + \
-             std::to_string(injections) + "\nTotal Injections: " + \
-             std::to_string(mem_injections) + "Reg Injections: " + \
+             std::to_string(injections) + "\nTotal Injections: "  + \
+             std::to_string(mem_injections) + "\nReg Injections: " + \
              std::to_string(reg_injections) + "\n");
 }
+
+// explicitly defines valid template types
+template void injector::inject<uint8_t>(uint8_t&);
+template void injector::inject<int8_t>(int8_t&);
+template void injector::inject<uint16_t>(uint16_t&);
+template void injector::inject<int16_t>(int16_t&);
+template void injector::inject<uint32_t>(uint32_t&);
+template void injector::inject<int32_t>(int32_t&);
+template void injector::inject<char>(char&);
+template void injector::inject<long int>(long int&);
+template void injector::inject<unsigned long int>(unsigned long int&);
+template void injector::inject<float>(float&);
+template void injector::inject<double>(double&);
+template void injector::inject<long double>(long double&);
+
+template void injector::inject<uint8_t>(uint8_t&, INJECTOR_MODE_TYPE);
+template void injector::inject<int8_t>(int8_t&, INJECTOR_MODE_TYPE);
+template void injector::inject<uint16_t>(uint16_t&, INJECTOR_MODE_TYPE);
+template void injector::inject<int16_t>(int16_t&, INJECTOR_MODE_TYPE);
+template void injector::inject<uint32_t>(uint32_t&, INJECTOR_MODE_TYPE);
+template void injector::inject<int32_t>(int32_t&, INJECTOR_MODE_TYPE);
+template void injector::inject<char>(char&, INJECTOR_MODE_TYPE);
+template void injector::inject<long int>(long int&, INJECTOR_MODE_TYPE);
+template void injector::inject<unsigned long int>(unsigned long int&, INJECTOR_MODE_TYPE);
+template void injector::inject<float>(float&, INJECTOR_MODE_TYPE);
+template void injector::inject<double>(double&, INJECTOR_MODE_TYPE);
+template void injector::inject<long double>(long double&, INJECTOR_MODE_TYPE);

--- a/src/injector.cpp
+++ b/src/injector.cpp
@@ -38,6 +38,7 @@ template <typename T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
         uint8_t mask = std::pow(2,bitPos); // generate bit mask
 
         bytes[bytePos] ^= mask; // flip bit in vale
+        injections++;
     }
     else if (mode == DOUBLE_DATA)
     {
@@ -54,10 +55,30 @@ template <typename T> void injector::inject(T &data, INJECTOR_MODE_TYPE mode)
         uint8_t mask2 = std::pow(2,bitPos2);
 
         bytes[bytePos1] ^= mask1;
-        bytes[bytePos2] ^= mask2;        
+        bytes[bytePos2] ^= mask2;
+        injections+=2;        
+    }
+    else if (mode == PROB_DATA)
+    {
+        unsigned long int oneOutOf = static_cast<unsigned long int>(1.0/reg_bit_hit_prob);
+        
+        // determine if each bit get's hit based on prob
+        for (int by = 0; by < size; ++by)
+        {
+            for (int bi = 0; bi < 8; bi++)
+            {
+                unsigned long int safe = std::rand() % oneOutOf;
+                if (!safe)
+                {
+                    bytes[by] ^= static_cast<uint8_t>(std::pow(2,bi));
+                    injections++;
+                }
+            }
+        }
+
     }
 
-    injections++;
+    
     return;
 }
 


### PR DESCRIPTION
Fault injector for testing reliability techniques. Highlights below, see README for more details.

### Summary of Changes
- Fault injector for testing
- three modes of operation
  - single error injection
  - double error injection
  - probabilistic error injection
- accepts Mat CV_32F type and most standard C++ types (int, float, double, uint8_t, etc...)