### PR TITLE
Result processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build_local
 .vscode/
 *.sh
+/images

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable( Harris
 	./src/abft.cpp
 	./src/main.cpp
 	./src/injector.cpp
+	./src/processing.cpp
 )
 
 target_include_directories( Harris

--- a/include/harris.h
+++ b/include/harris.h
@@ -9,7 +9,7 @@
 using namespace std;
 using namespace cv;
 
-#define BENCHMARK_RUN true
+#define BENCHMARK_RUN false
 
 #define ASSERTIONS_ON false
 #define LDPC_ON false

--- a/include/harris.h
+++ b/include/harris.h
@@ -9,6 +9,8 @@
 using namespace std;
 using namespace cv;
 
+#define BENCHMARK_RUN true
+
 #define ASSERTIONS_ON false
 #define LDPC_ON false
 #define CHECKPOINTING_ON false

--- a/include/harris.h
+++ b/include/harris.h
@@ -9,8 +9,6 @@
 using namespace std;
 using namespace cv;
 
-#define BENCHMARK_RUN false
-
 #define ASSERTIONS_ON false
 #define LDPC_ON false
 #define CHECKPOINTING_ON false

--- a/include/processing.h
+++ b/include/processing.h
@@ -12,6 +12,9 @@ class processing
 
     // reads a pointData vector from a binary file
     static bool readVector(std::vector<pointData> &out, std::string filename);
+
+    // process features using benchmark features and test features
+    static void process(std::vector<pointData> bench, std::vector<pointData> test, featureStats &stats);
 };
 
 

--- a/include/processing.h
+++ b/include/processing.h
@@ -1,0 +1,18 @@
+#ifndef PROCESSING_H
+#define PROCESSING_H
+
+#include "util.h"
+
+class processing
+{
+    public:
+
+    // saves pointData vector to a binary file
+    static void saveVector(std::vector<pointData> vect, std::string filename);
+
+    // reads a pointData vector from a binary file
+    static bool readVector(std::vector<pointData> &out, std::string filename);
+};
+
+
+#endif // PROCESSING_H

--- a/include/util.h
+++ b/include/util.h
@@ -9,6 +9,14 @@
 using namespace std;
 using namespace cv;
 
+struct featureStats {
+	uint missing_features; // number of features in benchmark not found in test
+	uint false_features;   // number of features found in test that don't have match in benchmark
+	uint bench_features;   // number of features in benchmark
+	uint test_features;    // number of features found in test
+	uint match_features;   // number of features that match between benchmark and test
+};
+
 struct pointData { 
     float cornerResponse;
 

--- a/include/util.h
+++ b/include/util.h
@@ -1,6 +1,8 @@
 /*
  *      Author: alexanderb
  */
+#ifndef UTIL_H
+#define UTIL_H
 
 #include <opencv2/opencv.hpp>
 
@@ -11,6 +13,8 @@ struct pointData {
     float cornerResponse;
 
     Point point;
+	bool operator==(const pointData &) const;
+	
 };
 
 struct by_cornerResponse { 
@@ -33,3 +37,5 @@ public:
 
 	static Mat MarkInImage(Mat& img, vector<pointData> points, int radius);
 };
+
+#endif // UTIL_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ using namespace std;
 Mat m_img;
 string filename;
 
-void doHarris(std::string filename) {
+void doHarris(std::string filename, bool benchmark) {
     int boxFilterSize = 3;
     int maximaSuppressionDimension = 15;
     bool gauss = true;
@@ -59,7 +59,7 @@ void doHarris(std::string filename) {
         cout << "Features Detected: "<<resPts.size()<<endl;
     #endif
 
-    if (BENCHMARK_RUN)
+    if (benchmark)
     {
         // save benchmark data to file
         processing::saveVector(resPts, filename);
@@ -108,12 +108,25 @@ void doHarris(std::string filename) {
 int main(int argc, char** argv) {
     // read image from file + error handling
     Mat img;
+    bool benchmark = false;
 
     if (argc == 1) {
         cout << "No image provided! Usage: ./Ex1 [path to image]" << endl << "Using default image: haus.jpg" << endl;
 
         img = imread("haus.jpg");
-    } else {
+    }
+    else if (argc == 3)
+    {
+        filename = argv[1];
+        img = imread(argv[1]);
+
+        if (std::string(argv[2]) == "benchmark")
+        {
+            benchmark = true;
+        }
+    } 
+    else 
+    {
         filename = argv[1];
         img = imread(argv[1]);
     }
@@ -121,7 +134,7 @@ int main(int argc, char** argv) {
     img.copyTo(m_img);
 
     auto t_before = high_resolution_clock::now();
-    doHarris(std::string(argv[1]));
+    doHarris(std::string(argv[1]),benchmark);
     auto t_after = high_resolution_clock::now();
     auto duration = duration_cast<microseconds>(t_after - t_before);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,12 +61,31 @@ void doHarris(std::string filename) {
 
     if (BENCHMARK_RUN)
     {
+        // save benchmark data to file
         processing::saveVector(resPts, filename);
     }
     else
     {
-        std::vector<pointData> gold;
-        processing::readVector(gold, filename);
+
+        std::vector<pointData> bench;
+        processing::readVector(bench, filename);
+
+        // simple tests (uncomment one or multiple)
+        resPts.erase(resPts.begin(),resPts.begin() + 10);
+        bench.erase(bench.begin() + 25, bench.begin() + 35);
+        resPts.at(45).point.x = 444;
+
+        // process results
+        featureStats stats;
+        processing::process(bench, resPts, stats);
+
+        // uncomment to print
+        cout<<"benchmark features: "<<stats.bench_features<<endl;
+        cout<<"benchmark features: "<<stats.bench_features<<endl;
+        cout<<"test features: "<<stats.test_features<<endl;
+        cout<<"missing features: "<<stats.missing_features<<endl;
+        cout<<"false features: "<<stats.false_features<<endl;
+        cout<<"matching features: "<<stats.match_features<<endl;
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 using namespace std::chrono;
 
 #include "../include/harris.h"
+#include "../include/processing.h"
 
 using namespace cv;
 using namespace std;
@@ -57,6 +58,20 @@ void doHarris() {
         cout << "Total time to get vector of points: " << duration.count()/1000 << " ms" << endl;
         cout << "Features Detected: "<<resPts.size()<<endl;
     #endif
+
+    processing::saveVector(resPts, std::string("test"));
+
+    std::vector<pointData> readPts;
+    processing::readVector(readPts, std::string("test"));
+    //std::cout<<resPts.size()<<endl;
+    if (resPts == readPts)
+    {
+        cout<<"values match"<<endl;
+    }
+    else
+    {
+        cout<<"values DO NOT match"<<endl;
+    }
 
     #ifdef LOCAL
     t_before = high_resolution_clock::now();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <opencv2/opencv.hpp>
 #include <chrono>
+#include <fstream>
 using namespace std::chrono;
 
 #include "../include/harris.h"
@@ -14,7 +15,7 @@ using namespace cv;
 using namespace std;
 
 // uncomment to allow for visual test on local machine
-#define LOCAL
+// #define LOCAL
 
 Mat m_img;
 string filename;
@@ -66,21 +67,21 @@ void doHarris(std::string filename, bool benchmark) {
     }
     else
     {
-
+        ifstream f(filename + ".dat");
+        assert(f.good());
         std::vector<pointData> bench;
         processing::readVector(bench, filename);
 
         // simple tests (uncomment one or multiple)
-        resPts.erase(resPts.begin(),resPts.begin() + 10);
-        bench.erase(bench.begin() + 25, bench.begin() + 35);
-        resPts.at(45).point.x = 444;
+        // resPts.erase(resPts.begin(),resPts.begin() + 10);
+        // bench.erase(bench.begin() + 25, bench.begin() + 35);
+        // resPts.at(45).point.x = 444;
 
         // process results
         featureStats stats;
         processing::process(bench, resPts, stats);
 
         // uncomment to print
-        cout<<"benchmark features: "<<stats.bench_features<<endl;
         cout<<"benchmark features: "<<stats.bench_features<<endl;
         cout<<"test features: "<<stats.test_features<<endl;
         cout<<"missing features: "<<stats.missing_features<<endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ using namespace std;
 Mat m_img;
 string filename;
 
-void doHarris() {
+void doHarris(std::string filename) {
     int boxFilterSize = 3;
     int maximaSuppressionDimension = 15;
     bool gauss = true;
@@ -59,19 +59,17 @@ void doHarris() {
         cout << "Features Detected: "<<resPts.size()<<endl;
     #endif
 
-    processing::saveVector(resPts, std::string("test"));
-
-    std::vector<pointData> readPts;
-    processing::readVector(readPts, std::string("test"));
-    //std::cout<<resPts.size()<<endl;
-    if (resPts == readPts)
+    if (BENCHMARK_RUN)
     {
-        cout<<"values match"<<endl;
+        processing::saveVector(resPts, filename);
     }
     else
     {
-        cout<<"values DO NOT match"<<endl;
+        std::vector<pointData> gold;
+        processing::readVector(gold, filename);
     }
+
+
 
     #ifdef LOCAL
     t_before = high_resolution_clock::now();
@@ -104,7 +102,7 @@ int main(int argc, char** argv) {
     img.copyTo(m_img);
 
     auto t_before = high_resolution_clock::now();
-    doHarris();
+    doHarris(std::string(argv[1]));
     auto t_after = high_resolution_clock::now();
     auto duration = duration_cast<microseconds>(t_after - t_before);
 

--- a/src/processing.cpp
+++ b/src/processing.cpp
@@ -1,0 +1,50 @@
+
+#include <fstream>
+#include "../include/processing.h"
+
+void processing::saveVector(std::vector<pointData> vect, std::string filename)
+{
+    // destination filename
+    std::string fn = filename + ".dat";
+
+    // ofstream to write data as binary
+    std::ofstream fout(fn, ios::binary);
+
+    // get size of vector
+    uint64_t size = vect.size();
+    
+    // write vector size to fout
+    fout.write((const char*)&size, sizeof(size));
+
+    // write vector data to fout
+    fout.write((const char*)&vect[0], size*sizeof(pointData));
+
+    // close fout and exit
+    fout.close();
+}
+
+bool processing::readVector(std::vector<pointData> &out, std::string filename)
+{
+    // data filename
+    std::string fn = filename + ".dat";
+
+    // ifstream to read binary data in
+    std::ifstream fin(fn, ios::binary);
+
+    // size value to get length of binary data
+    uint64_t size;
+
+    // read in size of data
+    fin.read((char*)&size, sizeof(uint64_t));
+
+    cout<<size<<endl;
+
+    // resize output vector
+    out.resize(size);
+
+    // read in binary data (vectors are contiguous in memory)
+    fin.read((char*)&out[0], size*sizeof(pointData));
+
+    // close fin and exit
+    fin.close();
+}

--- a/src/processing.cpp
+++ b/src/processing.cpp
@@ -37,8 +37,6 @@ bool processing::readVector(std::vector<pointData> &out, std::string filename)
     // read in size of data
     fin.read((char*)&size, sizeof(uint64_t));
 
-    cout<<size<<endl;
-
     // resize output vector
     out.resize(size);
 
@@ -47,4 +45,57 @@ bool processing::readVector(std::vector<pointData> &out, std::string filename)
 
     // close fin and exit
     fin.close();
+
+    return true;
+}
+
+void processing::process(std::vector<pointData> bench, std::vector<pointData> test, featureStats &stats)
+{
+ 
+    // extract number of features detected from both vectors
+    stats.bench_features = bench.size();
+    stats.test_features  = test.size();
+
+    // set window range
+    uint range = 5;
+
+    // initialize other stats values
+    stats.false_features = 0;
+    stats.missing_features = 0;
+    stats.match_features = 0;
+
+    for (uint i = 0; i < stats.bench_features; ++i)
+    {
+        // exctract current point
+        Point bpt = bench.at(i).point;
+
+        // flag for found match
+        bool match = false;
+
+        // search for match in test vector
+        for (uint j = 0; j < test.size(); ++j)
+        {
+            // extract test point
+            Point tpt = test.at(j).point;
+
+            // check if test point is within range of bench point
+            if (std::abs(tpt.x - bpt.x) <= range && std::abs(tpt.y - bpt.y) <= range)
+            {
+                test.erase(test.begin() + j); // erase point in test
+                stats.match_features++;       // increment number of matches
+                match = true;                 
+                break;
+            }
+        }
+
+        // if no match then it is a missing feature
+        if (!match)
+        {
+            stats.missing_features++;
+        }
+    }
+
+    // get number of false features as remaining points in test vector
+    stats.false_features = test.size();
+
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -82,3 +82,8 @@ Mat Util::MarkInImage(Mat& img, vector<pointData> points, int radius) {
 
 	return retImg;
 }
+
+bool pointData::operator==(const pointData &a) const
+{
+	return ((point.x == a.point.x)&&(point.y == a.point.y) && (cornerResponse == a.cornerResponse));
+}


### PR DESCRIPTION
addresses issue #3 by following feature comparison technique discussed in comments. 

the following functions and structs were added:
* `processing::saveVector()` - saves the benchmark features vector to a binary file. The file uses the same path and filename of the image and adds the .dat extention.
* `processing::readVector()` - reads in the saved benchmark for the image selected, modifies the output vector by reference.
* `processing::process()` - processes feature vectors by comparing the test features and the benchmark features and filling the `featureStats` structure.
* `featureStats` - struct that includes the following statistics:
    * `missing_features` - number of features in benchmark not found in test
    * `false_features` - number of features found in test that don't have match in benchmark
    * `bench_features` - number of features in the benchmark
    * `test_features` - number of features in the test results
    * `match_features` - number of features that match between the benchmark and the test

The `processing::process()` function determines a match if the test feature is within a 5 x 5 window of the benchmark figure. 

To trigger the benchmark generation simply pass the word *benchmark* into the program call after the image path like the following:

`./Harris ../images/gullies_on_mars.jpeg benchmark`

That will create a binary .dat file for the benchmark that can be used later for other runs. 